### PR TITLE
Add plugin to wave when greeted

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,15 @@ python -m jetson.main
 
 Plugins can be placed in the `plugins/` directory and will automatically be
 loaded on startup.
+
+### Example: Wave when greeted
+
+The `WaveHiPlugin` monitors `conversation.log` for user messages. When it sees
+"hi" or "hello" it performs a small wave with the arm and writes ``happy`` to
+``eye_command.txt`` so the Raspberry Pi eye program can switch expressions.
+
+```text
+You: hi bloopy
+[SERVO] Channel 4 -> angle=45 dur=0.5
+...
+```

--- a/plugins/wave_hi.py
+++ b/plugins/wave_hi.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import threading
+import time
+from pathlib import Path
+
+from jetson.plugin import BloopyPlugin
+from jetson.servo_api import CHANNELS, ServoCommand, move_servos
+
+
+class WaveHiPlugin(BloopyPlugin):
+    """Wave and show happy eyes when the user says hello."""
+
+    name = "wave_hi"
+
+    def run(self) -> None:  # pragma: no cover - plugin runs forever
+        thread = threading.Thread(target=self._watch_loop, daemon=True)
+        thread.start()
+
+    def _watch_loop(self) -> None:
+        log = Path("conversation.log")
+        log.touch(exist_ok=True)
+        position = log.stat().st_size
+        while True:
+            with log.open("r", encoding="utf-8") as f:
+                f.seek(position)
+                lines = f.readlines()
+                if lines:
+                    position = f.tell()
+                for line in lines:
+                    lower = line.lower()
+                    if lower.startswith("you:") and ("hi" in lower or "hello" in lower):
+                        self._wave_and_smile()
+            time.sleep(0.5)
+
+    def _wave_and_smile(self) -> None:
+        sequence = [
+            ServoCommand(channel=CHANNELS["shoulder_lift"], angle=45),
+            ServoCommand(channel=CHANNELS["elbow"], angle=90),
+        ]
+        move_servos(sequence)
+        for _ in range(2):
+            move_servos([ServoCommand(channel=CHANNELS["wrist"], angle=30)])
+            time.sleep(0.3)
+            move_servos([ServoCommand(channel=CHANNELS["wrist"], angle=-30)])
+            time.sleep(0.3)
+        move_servos([
+            ServoCommand(channel=CHANNELS["wrist"], angle=0),
+            ServoCommand(channel=CHANNELS["elbow"], angle=0),
+            ServoCommand(channel=CHANNELS["shoulder_lift"], angle=0),
+        ])
+        Path("eye_command.txt").write_text("happy\n", encoding="utf-8")


### PR DESCRIPTION
## Summary
- implement `WaveHiPlugin` that monitors conversation log for greetings
- update README with example usage

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_685d5d93a2b08328971004a79f6e7806